### PR TITLE
fix(system_mgmt): 补齐用户导入、NATS 校验与密码策略描述的 i18n

### DIFF
--- a/server/apps/system_mgmt/language/en.yaml
+++ b/server/apps/system_mgmt/language/en.yaml
@@ -101,6 +101,17 @@ error:
   user_ids_list_required: user_ids must be a non-empty list
   invalid_user_status_action: Action must be one of enable, disable, or unlock
   invalid_user_ids: 'Invalid user IDs: {ids}'
+  import_users_empty: No users available to import
+  import_users_limit: You can import at most 500 users at a time
+  import_users_invalid_row: Invalid data format
+  import_users_missing_fields: Required fields are missing
+  import_users_username_exists: Username already exists
+  import_users_invalid_email: Invalid email format
+  import_users_create_failed: Failed to create user
+  nats_config_must_be_object: NATS config must be an object
+  nats_supports_notify_person_boolean: must be a boolean
+  nats_mode_unsupported: unsupported NATS extension mode
+  nats_subject_key_in_use: notification topic identifier is already in use
   synced_users_delete_forbidden: Synced users cannot be deleted directly. Please delete them from the user sync source.
   synced_group_child_creation_forbidden: Synced groups cannot have manually created child groups
   cannot_create_under_archived_group: Cannot create a group under an archived organization
@@ -127,6 +138,9 @@ password:
   char_type_lowercase: lowercase letter
   char_type_digit: number
   char_type_special: special character
+  policy_must_contain: 'Must contain: {types}'
+  policy_no_special_requirement: No special requirements
+  policy_description: "Password policy:\n1. Length must be {min_length}-{max_length} characters\n2. {type_desc}\n3. Special characters include: !@#$%^&*()_+-=[]{{}};\\'\"\\|,.<>?/~`"
 login:
   incorrect_password_with_attempts: Username or password is incorrect. {attempts}
     attempts remaining.

--- a/server/apps/system_mgmt/language/zh-Hans.yaml
+++ b/server/apps/system_mgmt/language/zh-Hans.yaml
@@ -97,6 +97,17 @@ error:
   user_ids_list_required: user_ids 必须是非空列表
   invalid_user_status_action: action 必须是 enable、disable 或 unlock
   invalid_user_ids: '非法的用户 ID: {ids}'
+  import_users_empty: 没有可导入的用户数据
+  import_users_limit: 单次最多导入 500 名用户
+  import_users_invalid_row: 数据格式不正确
+  import_users_missing_fields: 缺少必填字段
+  import_users_username_exists: 用户名已存在
+  import_users_invalid_email: 邮箱格式不正确
+  import_users_create_failed: 创建用户失败
+  nats_config_must_be_object: NATS 配置必须是对象
+  nats_supports_notify_person_boolean: 必须是布尔值
+  nats_mode_unsupported: 不支持的 NATS 扩展模式
+  nats_subject_key_in_use: 通知主题标识已被使用
   synced_users_delete_forbidden: 同步用户不能直接删除，请从用户同步源中删除。
   synced_group_child_creation_forbidden: 同步组织下不能手动创建子组织
   cannot_create_under_archived_group: 不能在已归档组织下创建子组织
@@ -123,6 +134,9 @@ password:
   char_type_lowercase: 小写字母
   char_type_digit: 数字
   char_type_special: 特殊符号
+  policy_must_contain: '必须包含：{types}'
+  policy_no_special_requirement: 无特殊要求
+  policy_description: "密码策略要求：\n1. 长度为 {min_length}-{max_length} 个字符\n2. {type_desc}\n3. 特殊符号包括：!@#$%^&*()_+-=[]{{}};\\'\"\\|,.<>?/~`"
 login:
   incorrect_password_with_attempts: 用户名或密码错误。剩余尝试次数:{attempts} 次。
   password_expired: 您的密码已过期,请立即修改密码。

--- a/server/apps/system_mgmt/serializers/channel_serializer.py
+++ b/server/apps/system_mgmt/serializers/channel_serializer.py
@@ -39,20 +39,19 @@ class ChannelSerializer(UsernameSerializer):
                 raise serializers.ValidationError(self._loader().get("error.channel_team_required")) from exc
         return team_ids
 
-    @classmethod
-    def validate_nats_config(cls, config):
+    def validate_nats_config(self, config):
+        loader = self._loader()
         if not isinstance(config, dict):
-            raise serializers.ValidationError({"config": "NATS config must be an object"})
+            raise serializers.ValidationError({"config": loader.get("error.nats_config_must_be_object")})
         if "supports_notify_person" in config and not isinstance(config["supports_notify_person"], bool):
-            raise serializers.ValidationError({"config": {"supports_notify_person": "must be a boolean"}})
+            raise serializers.ValidationError({"config": {"supports_notify_person": loader.get("error.nats_supports_notify_person_boolean")}})
         if nats_notifications is not None and nats_notifications.handles_config(config):
             return nats_notifications.validate_config(config)
         if config.get("nats_mode") not in (None, "request_reply"):
-            raise serializers.ValidationError({"config": {"nats_mode": "unsupported NATS extension mode"}})
+            raise serializers.ValidationError({"config": {"nats_mode": loader.get("error.nats_mode_unsupported")}})
         return config
 
-    @classmethod
-    def validate_nats_subject_key_unique(cls, config, exclude_channel_id=None):
+    def validate_nats_subject_key_unique(self, config, exclude_channel_id=None):
         if nats_notifications is None or not nats_notifications.handles_config(config):
             return
 
@@ -65,7 +64,7 @@ class ChannelSerializer(UsernameSerializer):
         if exclude_channel_id is not None:
             channels = channels.exclude(pk=exclude_channel_id)
         if channels.exists():
-            raise serializers.ValidationError({"config": {"subject_key": "notification topic identifier is already in use"}})
+            raise serializers.ValidationError({"config": {"subject_key": self._loader().get("error.nats_subject_key_in_use")}})
 
     def validate(self, attrs):
         attrs = super().validate(attrs)

--- a/server/apps/system_mgmt/tests/test_channel_serializer.py
+++ b/server/apps/system_mgmt/tests/test_channel_serializer.py
@@ -1,11 +1,27 @@
+from types import SimpleNamespace
+
 import pytest
+from django.test import RequestFactory
 
 from apps.system_mgmt.models import Channel, ChannelChoices
 from apps.system_mgmt.serializers import ChannelSerializer
 
 
+def _request_with_locale(locale):
+    request = RequestFactory().post("/system_mgmt/api/")
+    request.user = SimpleNamespace(locale=locale)
+    return request
+
+
 @pytest.mark.django_db
-def test_event_publish_channel_rejects_duplicate_subject_key():
+@pytest.mark.parametrize(
+    ("locale", "expected"),
+    [
+        ("en", "notification topic identifier is already in use"),
+        ("zh-Hans", "通知主题标识已被使用"),
+    ],
+)
+def test_event_publish_channel_rejects_duplicate_subject_key(locale, expected):
     Channel.objects.create(
         name="existing-event-publish",
         channel_type=ChannelChoices.NATS,
@@ -21,11 +37,12 @@ def test_event_publish_channel_rejects_duplicate_subject_key():
             "description": "Duplicate event publish channel",
             "team": [],
             "config": {"nats_mode": "event_publish", "subject_key": "customer-alerts"},
-        }
+        },
+        context={"request": _request_with_locale(locale)},
     )
 
     assert serializer.is_valid() is False
-    assert serializer.errors["config"]["subject_key"] == "notification topic identifier is already in use"
+    assert serializer.errors["config"]["subject_key"] == expected
 
 
 @pytest.mark.django_db

--- a/server/apps/system_mgmt/tests/test_i18n_4465.py
+++ b/server/apps/system_mgmt/tests/test_i18n_4465.py
@@ -134,6 +134,47 @@ def test_import_users_row_messages_use_request_locale(monkeypatch, locale, users
 @pytest.mark.parametrize(
     ("locale", "expected"),
     [
+        ("en", "Failed to create user"),
+        ("zh-Hans", "创建用户失败"),
+    ],
+)
+def test_import_users_create_failed_uses_request_locale(monkeypatch, locale, expected):
+    class Atomic:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    _stub_import_users_group_lookup(monkeypatch)
+    monkeypatch.setattr(
+        "apps.system_mgmt.viewset.user_viewset.User.objects.filter",
+        lambda **kwargs: SimpleNamespace(exists=lambda: False),
+    )
+    monkeypatch.setattr("apps.system_mgmt.viewset.user_viewset.transaction.atomic", Atomic)
+    monkeypatch.setattr("apps.system_mgmt.viewset.user_viewset.logger.exception", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "apps.system_mgmt.viewset.user_viewset.User.objects.create",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("create failed")),
+    )
+    request = request_with_locale(locale)
+    request.data = {
+        "group_id": 1,
+        "file_name": "users.xlsx",
+        "users": [{"username": "new-import-user", "lastName": "A", "email": "a@example.com"}],
+    }
+    response = UserViewSet.import_users.__wrapped__(UserViewSet(), request)
+    payload = response_payload(response)
+    assert response.status_code == 200
+    assert payload["result"] is True
+    assert payload["data"]["failures"] == [
+        {"row_number": 2, "username": "new-import-user", "message": expected},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("locale", "expected"),
+    [
         ("en", "Password policy:"),
         ("zh-Hans", "密码策略要求："),
     ],

--- a/server/apps/system_mgmt/tests/test_i18n_4465.py
+++ b/server/apps/system_mgmt/tests/test_i18n_4465.py
@@ -86,7 +86,51 @@ def test_import_users_boundary_messages_use_request_locale(locale, users, expect
     assert response_payload(response) == {"result": False, "message": expected}
 
 
-@pytest.mark.django_db
+def _stub_import_users_group_lookup(monkeypatch):
+    monkeypatch.setattr("apps.system_mgmt.viewset.user_viewset._validate_selected_groups", lambda groups, loader: None)
+    monkeypatch.setattr("apps.system_mgmt.viewset.user_viewset._normalize_group_ids", lambda groups: ([1], []))
+    monkeypatch.setattr(UserViewSet, "_validate_group_scope_for_request", lambda self, request, groups, loader: None)
+    monkeypatch.setattr(
+        "apps.system_mgmt.viewset.user_viewset.GroupUtils.active_queryset",
+        lambda: SimpleNamespace(filter=lambda **kwargs: SimpleNamespace(first=lambda: SimpleNamespace(id=1, name="org"))),
+    )
+    monkeypatch.setattr(
+        "apps.system_mgmt.viewset.user_viewset.SystemSettings.objects.filter",
+        lambda **kwargs: SimpleNamespace(values_list=lambda *args, **kw: []),
+    )
+    monkeypatch.setattr("apps.system_mgmt.viewset.user_viewset.log_operation", lambda *args, **kwargs: None)
+
+
+@pytest.mark.parametrize(
+    ("locale", "users", "expected"),
+    [
+        ("en", ["not-a-row"], "Invalid data format"),
+        ("zh-Hans", ["not-a-row"], "数据格式不正确"),
+        ("en", [{"username": "", "lastName": "A", "email": "a@example.com"}], "Required fields are missing"),
+        ("zh-Hans", [{"username": "", "lastName": "A", "email": "a@example.com"}], "缺少必填字段"),
+        ("en", [{"username": "bad-phone", "lastName": "A", "email": "a@example.com", "phone": "abc"}], "Invalid phone number format"),
+        ("zh-Hans", [{"username": "bad-phone", "lastName": "A", "email": "a@example.com", "phone": "abc"}], "手机号格式不正确"),
+        ("en", [{"username": "bad-email", "lastName": "A", "email": "not-an-email"}], "Invalid email format"),
+        ("zh-Hans", [{"username": "bad-email", "lastName": "A", "email": "not-an-email"}], "邮箱格式不正确"),
+        ("en", [{"username": "existing", "lastName": "A", "email": "a@example.com"}], "Username already exists"),
+        ("zh-Hans", [{"username": "existing", "lastName": "A", "email": "a@example.com"}], "用户名已存在"),
+    ],
+)
+def test_import_users_row_messages_use_request_locale(monkeypatch, locale, users, expected):
+    _stub_import_users_group_lookup(monkeypatch)
+    monkeypatch.setattr(
+        "apps.system_mgmt.viewset.user_viewset.User.objects.filter",
+        lambda **kwargs: SimpleNamespace(exists=lambda: kwargs.get("username") == "existing"),
+    )
+    request = request_with_locale(locale)
+    request.data = {"group_id": 1, "users": users, "file_name": "users.xlsx"}
+    response = UserViewSet.import_users.__wrapped__(UserViewSet(), request)
+    payload = response_payload(response)
+    assert response.status_code == 200
+    assert payload["result"] is True
+    assert payload["data"]["failures"][0]["message"] == expected
+
+
 @pytest.mark.parametrize(
     ("locale", "expected"),
     [
@@ -94,10 +138,23 @@ def test_import_users_boundary_messages_use_request_locale(locale, users, expect
         ("zh-Hans", "密码策略要求："),
     ],
 )
-def test_password_policy_description_uses_requested_locale(locale, expected):
+def test_password_policy_description_uses_requested_locale(monkeypatch, locale, expected):
+    monkeypatch.setattr(
+        PasswordValidator,
+        "get_password_settings",
+        staticmethod(lambda: {
+            "min_length": 8,
+            "max_length": 20,
+            "required_char_types": ["uppercase", "lowercase", "digit", "special"],
+        }),
+    )
     description = PasswordValidator.get_password_policy_description(locale=locale)
     assert expected in description
     assert "8-20" in description
+    if locale == "zh-Hans":
+        assert "必须包含：大写字母, 小写字母, 数字, 特殊符号" in description
+    else:
+        assert "Must contain: uppercase letter, lowercase letter, number, special character" in description
 
 
 @pytest.mark.parametrize(
@@ -121,6 +178,37 @@ def test_nats_config_validation_uses_requested_locale(locale, config, path, expe
     for key in path:
         detail = detail[key]
     assert str(detail) == expected
+
+
+@pytest.mark.parametrize(
+    ("locale", "expected"),
+    [
+        ("en", "notification topic identifier is already in use"),
+        ("zh-Hans", "通知主题标识已被使用"),
+    ],
+)
+def test_nats_subject_key_unique_uses_requested_locale(monkeypatch, locale, expected):
+    class DuplicateSubjectQuerySet:
+        def exclude(self, **kwargs):
+            return self
+
+        def exists(self):
+            return True
+
+    monkeypatch.setattr(
+        "apps.system_mgmt.serializers.channel_serializer.nats_notifications",
+        SimpleNamespace(handles_config=lambda config: True),
+    )
+    monkeypatch.setattr(
+        "apps.system_mgmt.serializers.channel_serializer.Channel.objects.filter",
+        lambda **kwargs: DuplicateSubjectQuerySet(),
+    )
+    serializer = object.__new__(ChannelSerializer)
+    serializer.parent = None
+    serializer._context = {"request": request_with_locale(locale)}
+    with pytest.raises(ValidationError) as exc_info:
+        serializer.validate_nats_subject_key_unique({"subject_key": "customer-alerts"})
+    assert str(exc_info.value.detail["config"]["subject_key"]) == expected
 
 
 @pytest.mark.parametrize(

--- a/server/apps/system_mgmt/tests/test_i18n_4465.py
+++ b/server/apps/system_mgmt/tests/test_i18n_4465.py
@@ -70,6 +70,60 @@ def test_password_validator_uses_requested_locale(locale, expected):
 
 
 @pytest.mark.parametrize(
+    ("locale", "users", "expected"),
+    [
+        ("en", [], "No users available to import"),
+        ("zh-Hans", [], "没有可导入的用户数据"),
+        ("en", [{}] * 501, "You can import at most 500 users at a time"),
+        ("zh-Hans", [{}] * 501, "单次最多导入 500 名用户"),
+    ],
+)
+def test_import_users_boundary_messages_use_request_locale(locale, users, expected):
+    request = request_with_locale(locale)
+    request.data = {"group_id": 1, "users": users, "file_name": "users.xlsx"}
+    response = UserViewSet.import_users.__wrapped__(UserViewSet(), request)
+    assert response.status_code == 400
+    assert response_payload(response) == {"result": False, "message": expected}
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("locale", "expected"),
+    [
+        ("en", "Password policy:"),
+        ("zh-Hans", "密码策略要求："),
+    ],
+)
+def test_password_policy_description_uses_requested_locale(locale, expected):
+    description = PasswordValidator.get_password_policy_description(locale=locale)
+    assert expected in description
+    assert "8-20" in description
+
+
+@pytest.mark.parametrize(
+    ("locale", "config", "path", "expected"),
+    [
+        ("en", "not-an-object", ("config",), "NATS config must be an object"),
+        ("zh-Hans", "not-an-object", ("config",), "NATS 配置必须是对象"),
+        ("en", {"supports_notify_person": "true"}, ("config", "supports_notify_person"), "must be a boolean"),
+        ("zh-Hans", {"supports_notify_person": "true"}, ("config", "supports_notify_person"), "必须是布尔值"),
+        ("en", {"nats_mode": "unknown-mode"}, ("config", "nats_mode"), "unsupported NATS extension mode"),
+        ("zh-Hans", {"nats_mode": "unknown-mode"}, ("config", "nats_mode"), "不支持的 NATS 扩展模式"),
+    ],
+)
+def test_nats_config_validation_uses_requested_locale(locale, config, path, expected):
+    serializer = object.__new__(ChannelSerializer)
+    serializer.parent = None
+    serializer._context = {"request": request_with_locale(locale)}
+    with pytest.raises(ValidationError) as exc_info:
+        serializer.validate_nats_config(config)
+    detail = exc_info.value.detail
+    for key in path:
+        detail = detail[key]
+    assert str(detail) == expected
+
+
+@pytest.mark.parametrize(
     ("serializer_class", "input_value", "expected"),
     [
         (ChannelSerializer, None, "Please select the channel organization"),

--- a/server/apps/system_mgmt/tests/test_org_scope_permissions.py
+++ b/server/apps/system_mgmt/tests/test_org_scope_permissions.py
@@ -385,7 +385,7 @@ def test_import_users_creates_valid_rows_and_reports_conflicts():
         "total_count": 2,
         "success_count": 1,
         "failed_count": 1,
-        "failures": [{"row_number": 3, "username": "existing-import-user", "message": "用户名已存在"}],
+        "failures": [{"row_number": 3, "username": "existing-import-user", "message": "Username already exists"}],
     }
     user = User.objects.get(username="new-import-user")
     assert user.group_list == [group.id]

--- a/server/apps/system_mgmt/utils/password_validator.py
+++ b/server/apps/system_mgmt/utils/password_validator.py
@@ -127,7 +127,7 @@ class PasswordValidator:
         return True, ""
 
     @classmethod
-    def get_password_policy_description(cls) -> str:
+    def get_password_policy_description(cls, locale: str = "zh-Hans") -> str:
         """
         获取密码策略描述文本
 
@@ -138,9 +138,20 @@ class PasswordValidator:
         min_length = config["min_length"]
         max_length = config["max_length"]
         required_types = config["required_char_types"]
+        loader = LanguageLoader(app="system_mgmt", default_lang=locale or "zh-Hans")
 
-        # 构建字符类型要求描述
-        type_names = [cls.CHAR_TYPE_NAMES.get(t, t) for t in required_types if t in cls.CHAR_TYPE_NAMES]
-        type_desc = f"必须包含：{', '.join(type_names)}" if type_names else "无特殊要求"
+        type_names = [
+            loader.get(f"password.char_type_{char_type}", cls.CHAR_TYPE_NAMES.get(char_type, char_type))
+            for char_type in required_types
+            if char_type in cls.CHAR_TYPE_NAMES
+        ]
+        type_desc = (
+            loader.get("password.policy_must_contain", "必须包含：{types}").format(types=", ".join(type_names))
+            if type_names
+            else loader.get("password.policy_no_special_requirement", "无特殊要求")
+        )
 
-        return f"密码策略要求：\n" f"1. 长度为 {min_length}-{max_length} 个字符\n" f"2. {type_desc}\n" f"3. 特殊符号包括：!@#$%^&*()_+-=[]{{}};\\'\"\\|,.<>?/~`"
+        return loader.get(
+            "password.policy_description",
+            "密码策略要求：\n1. 长度为 {min_length}-{max_length} 个字符\n2. {type_desc}\n3. 特殊符号包括：!@#$%^&*()_+-=[]{{}};\\'\"\\|,.<>?/~`",
+        ).format(min_length=min_length, max_length=max_length, type_desc=type_desc)

--- a/server/apps/system_mgmt/viewset/channel_viewset.py
+++ b/server/apps/system_mgmt/viewset/channel_viewset.py
@@ -265,8 +265,9 @@ class ChannelViewSet(viewsets.ModelViewSet, GenericViewSetFun):
             config.setdefault("webhook_url", obj.config["webhook_url"])
         elif obj.channel_type == "nats":
             try:
-                ChannelSerializer.validate_nats_config(config)
-                ChannelSerializer.validate_nats_subject_key_unique(config, exclude_channel_id=obj.pk)
+                serializer = ChannelSerializer(instance=obj, context={"request": request})
+                serializer.validate_nats_config(config)
+                serializer.validate_nats_subject_key_unique(config, exclude_channel_id=obj.pk)
             except serializers.ValidationError as exc:
                 return Response({"result": False, "message": exc.detail}, status=400)
         obj.config = config

--- a/server/apps/system_mgmt/viewset/system_settings_viewset.py
+++ b/server/apps/system_mgmt/viewset/system_settings_viewset.py
@@ -241,7 +241,7 @@ class SystemSettingsViewSet(viewsets.ModelViewSet):
         # 转换为字典格式
         settings_dict = {item["key"]: item["value"] for item in password_settings}
 
-        # 添加密码策略描述
-        policy_description = PasswordValidator.get_password_policy_description()
+        locale = getattr(getattr(request, "user", None), "locale", "zh-Hans") or "zh-Hans"
+        policy_description = PasswordValidator.get_password_policy_description(locale=locale)
 
         return JsonResponse({"result": True, "data": {"settings": settings_dict, "policy_description": policy_description}})

--- a/server/apps/system_mgmt/viewset/user_viewset.py
+++ b/server/apps/system_mgmt/viewset/user_viewset.py
@@ -529,9 +529,9 @@ class UserViewSet(ViewSetUtils):
         rows = request.data.get("users")
         file_name = str(request.data.get("file_name") or "")
         if not isinstance(rows, list) or not rows:
-            return JsonResponse({"result": False, "message": "没有可导入的用户数据"}, status=400)
+            return JsonResponse({"result": False, "message": loader.get("error.import_users_empty")}, status=400)
         if len(rows) > 500:
-            return JsonResponse({"result": False, "message": "单次最多导入 500 名用户"}, status=400)
+            return JsonResponse({"result": False, "message": loader.get("error.import_users_limit")}, status=400)
 
         group_error = _validate_selected_groups([group_id], loader)
         if group_error:
@@ -553,7 +553,7 @@ class UserViewSet(ViewSetUtils):
         initial_password_enabled = settings.get("user_create_initial_password_enabled") == "1"
         initial_password_hash = settings.get("user_create_initial_password_hash", "")
         if initial_password_enabled and not initial_password_hash:
-            return JsonResponse({"result": False, "message": "本地用户初始密码未配置"}, status=400)
+            return JsonResponse({"result": False, "message": loader.get("error.initial_password_not_configured")}, status=400)
 
         failures = []
         successful_usernames = set()
@@ -562,18 +562,18 @@ class UserViewSet(ViewSetUtils):
             username = str(row.get("username", "")).strip() if isinstance(row, dict) else ""
             failure = None
             if not isinstance(row, dict):
-                failure = "数据格式不正确"
+                failure = loader.get("error.import_users_invalid_row")
             elif not all(str(row.get(field, "")).strip() for field in ("username", "lastName", "email")):
-                failure = "缺少必填字段"
+                failure = loader.get("error.import_users_missing_fields")
             elif username in successful_usernames or User.objects.filter(username=username, domain="domain.com").exists():
-                failure = "用户名已存在"
+                failure = loader.get("error.import_users_username_exists")
             elif not self._is_valid_phone(row.get("phone", "")):
-                failure = "手机号格式不正确"
+                failure = loader.get("error.invalid_phone")
             else:
                 try:
                     validate_email(str(row["email"]).strip())
                 except ValidationError:
-                    failure = "邮箱格式不正确"
+                    failure = loader.get("error.import_users_invalid_email")
 
             if failure:
                 failures.append({"row_number": row_number, "username": username, "message": failure})
@@ -593,7 +593,7 @@ class UserViewSet(ViewSetUtils):
                 successful_usernames.add(username)
             except Exception:
                 logger.exception("用户导入失败 username=%s", username)
-                failures.append({"row_number": row_number, "username": username, "message": "创建用户失败"})
+                failures.append({"row_number": row_number, "username": username, "message": loader.get("error.import_users_create_failed")})
 
         result = {
             "total_count": len(rows),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the remaining approved `system_mgmt` i18n leftovers from upstream issue [TencentBlueKing/bk-lite#4465](https://github.com/TencentBlueKing/bk-lite/issues/4465). Frontend items 001–004 are already fixed on this fork and are not touched.

- User import path (`import_users`) now returns `LanguageLoader` messages instead of hardcoded Chinese.
- NATS channel validation messages go through the same serializer `_loader()` pattern as neighboring serializers.
- Password policy descriptions are built from locale YAML instead of a hardcoded Chinese template.

## Scope

In scope:
- `user_viewset.import_users` leftover Chinese API/row messages
- `channel_serializer` NATS validation messages
- `password_validator.get_password_policy_description`
- matching `en.yaml` / `zh-Hans.yaml` keys
- bilingual regression tests, including `error.import_users_create_failed`

Callers updated only so locale actually reaches these messages:
- `channel_viewset.update_settings` instantiates `ChannelSerializer` with request context
- `system_settings_viewset.get_password_settings` passes `request.user.locale`

Out of scope: frontend 001–004, operation-log strings, other leftover viewset/serializer messages from I18N-SYS-006.

## Files changed

- `server/apps/system_mgmt/viewset/user_viewset.py`
- `server/apps/system_mgmt/serializers/channel_serializer.py`
- `server/apps/system_mgmt/viewset/channel_viewset.py`
- `server/apps/system_mgmt/utils/password_validator.py`
- `server/apps/system_mgmt/viewset/system_settings_viewset.py`
- `server/apps/system_mgmt/language/en.yaml`
- `server/apps/system_mgmt/language/zh-Hans.yaml`
- `server/apps/system_mgmt/tests/test_i18n_4465.py`
- `server/apps/system_mgmt/tests/test_channel_serializer.py`
- `server/apps/system_mgmt/tests/test_org_scope_permissions.py`

## Test plan

Ran:

```bash
cd server && DB_ENGINE=sqlite DB_NAME=:memory: SECRET_KEY=cursor-cloud-dev ENABLE_CELERY=true \
  uv run pytest apps/system_mgmt/tests/test_i18n_4465.py::test_import_users_create_failed_uses_request_locale --no-cov
```

Result: **2 passed** (en `Failed to create user`, zh-Hans `创建用户失败`). Neighboring import-row locale tests also still pass.

Do not merge this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2901a768-8ce5-47a8-b4f0-247fec5e6671?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2901a768-8ce5-47a8-b4f0-247fec5e6671&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

